### PR TITLE
feat: AnalysisQueue — 自動解析キュー・リトライ・オフライン対応 (Issue #7)

### DIFF
--- a/src/Mnemo/Mnemo.xcodeproj/project.pbxproj
+++ b/src/Mnemo/Mnemo.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		AA000020 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB000020 /* APIClient.swift */; };
 		AA000021 /* AnalysisRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB000021 /* AnalysisRepository.swift */; };
 		AA000022 /* TagChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB000022 /* TagChip.swift */; };
+		AA000023 /* AnalysisQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB000023 /* AnalysisQueue.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -54,6 +55,7 @@
 		AB000020 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		AB000021 /* AnalysisRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisRepository.swift; sourceTree = "<group>"; };
 		AB000022 /* TagChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagChip.swift; sourceTree = "<group>"; };
+		AB000023 /* AnalysisQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisQueue.swift; sourceTree = "<group>"; };
 		AC000001 /* Mnemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Mnemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -172,6 +174,7 @@
 			children = (
 				AB000014 /* ImageStorage.swift */,
 				AB000020 /* APIClient.swift */,
+				AB000023 /* AnalysisQueue.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -300,6 +303,7 @@
 				AA000020 /* APIClient.swift in Sources */,
 				AA000021 /* AnalysisRepository.swift in Sources */,
 				AA000022 /* TagChip.swift in Sources */,
+				AA000023 /* AnalysisQueue.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/Mnemo/Mnemo/MnemoApp.swift
+++ b/src/Mnemo/Mnemo/MnemoApp.swift
@@ -3,17 +3,48 @@ import SwiftData
 
 @main
 struct MnemoApp: App {
-    var body: some Scene {
-        WindowGroup {
-            ContentView()
-        }
-        .modelContainer(for: [
+    private let container: ModelContainer
+    @State private var analysisQueue: AnalysisQueue
+
+    init() {
+        // ModelContainer を明示的に作成
+        let container = try! ModelContainer(for:
             Screenshot.self,
             Tag.self,
             Collection.self,
             CollectionItem.self,
             OCRText.self,
-            Embedding.self,
-        ])
+            Embedding.self
+        )
+        self.container = container
+
+        // APIClient の設定
+        // TODO: Phase 4（設定画面）で UserDefaults から動的に読み込む
+        let apiClient = APIClient(
+            baseURL: URL(string: "http://localhost:8000")!,
+            apiKey: ""
+        )
+
+        let modelContext = container.mainContext
+        let analysisRepository = AnalysisRepository(
+            modelContext: modelContext,
+            apiClient: apiClient
+        )
+        let queue = AnalysisQueue(
+            modelContext: modelContext,
+            analysisRepository: analysisRepository
+        )
+        self._analysisQueue = State(initialValue: queue)
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(analysisQueue)
+                .task {
+                    analysisQueue.start()
+                }
+        }
+        .modelContainer(container)
     }
 }

--- a/src/Mnemo/Mnemo/MnemoApp.swift
+++ b/src/Mnemo/Mnemo/MnemoApp.swift
@@ -5,23 +5,32 @@ import SwiftData
 struct MnemoApp: App {
     private let container: ModelContainer
     @State private var analysisQueue: AnalysisQueue
+    @Environment(\.scenePhase) private var scenePhase
 
     init() {
         // ModelContainer を明示的に作成
-        let container = try! ModelContainer(for:
-            Screenshot.self,
-            Tag.self,
-            Collection.self,
-            CollectionItem.self,
-            OCRText.self,
-            Embedding.self
-        )
-        self.container = container
+        do {
+            let container = try ModelContainer(for:
+                Screenshot.self,
+                Tag.self,
+                Collection.self,
+                CollectionItem.self,
+                OCRText.self,
+                Embedding.self
+            )
+            self.container = container
+        } catch {
+            fatalError("Failed to create ModelContainer: \(error.localizedDescription)")
+        }
 
         // APIClient の設定
         // TODO: Phase 4（設定画面）で UserDefaults から動的に読み込む
+        let baseURLString = "http://localhost:8000"
+        guard let baseURL = URL(string: baseURLString) else {
+            fatalError("Invalid base URL: \(baseURLString)")
+        }
         let apiClient = APIClient(
-            baseURL: URL(string: "http://localhost:8000")!,
+            baseURL: baseURL,
             apiKey: ""
         )
 
@@ -35,16 +44,25 @@ struct MnemoApp: App {
             analysisRepository: analysisRepository
         )
         self._analysisQueue = State(initialValue: queue)
+        
+        // AnalysisQueue を起動
+        queue.start()
     }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environment(analysisQueue)
-                .task {
-                    analysisQueue.start()
-                }
         }
         .modelContainer(container)
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .background {
+                // バックグラウンド移行時にキューをクリーンアップ
+                analysisQueue.stop()
+            } else if newPhase == .active {
+                // フォアグラウンド復帰時にキューを再開
+                analysisQueue.start()
+            }
+        }
     }
 }

--- a/src/Mnemo/Mnemo/Repositories/AnalysisRepository.swift
+++ b/src/Mnemo/Mnemo/Repositories/AnalysisRepository.swift
@@ -49,9 +49,10 @@ final class AnalysisRepository {
         // 4. レスポンスから SwiftData に保存
         saveAnalysisResult(response, for: screenshot)
 
-        // 5. status を success に更新
+        // 5. status を success に更新（エラー情報もクリア）
         screenshot.status = .success
         screenshot.errorMessage = nil
+        screenshot.retryCount = 0
         screenshot.updatedAt = Date()
         try modelContext.save()
     }

--- a/src/Mnemo/Mnemo/Repositories/AnalysisRepository.swift
+++ b/src/Mnemo/Mnemo/Repositories/AnalysisRepository.swift
@@ -27,45 +27,33 @@ final class AnalysisRepository {
     /// 4. レスポンスから OCRText, Tag(auto), Embedding を作成
     /// 5. status を .success に更新
     ///
-    /// エラー時は status を .failed に更新し、errorMessage を記録する
-    func analyzeScreenshot(_ screenshot: Screenshot) async {
+    /// 失敗時はエラーを throw する。ステータス管理は呼び出し元（AnalysisQueue）の責務。
+    func analyzeScreenshot(_ screenshot: Screenshot) async throws {
         // 1. status を processing に更新
         screenshot.status = .processing
         screenshot.updatedAt = Date()
         try? modelContext.save()
 
-        do {
-            // 2. 画像ファイルを読み込み（バックグラウンドで実行）
-            let imageURL = try ImageStorage.resolveURL(relativePath: screenshot.localPath)
-            let imageData = try await Task.detached(priority: .background) {
-                try Data(contentsOf: imageURL)
-            }.value
+        // 2. 画像ファイルを読み込み（バックグラウンドで実行）
+        let imageURL = try ImageStorage.resolveURL(relativePath: screenshot.localPath)
+        let imageData = try await Task.detached(priority: .background) {
+            try Data(contentsOf: imageURL)
+        }.value
 
-            // 3. APIClient で /analyze に送信
-            let response = try await apiClient.analyze(
-                imageData: imageData,
-                imageId: screenshot.id
-            )
+        // 3. APIClient で /analyze に送信
+        let response = try await apiClient.analyze(
+            imageData: imageData,
+            imageId: screenshot.id
+        )
 
-            // 4. レスポンスから SwiftData に保存
-            saveAnalysisResult(response, for: screenshot)
+        // 4. レスポンスから SwiftData に保存
+        saveAnalysisResult(response, for: screenshot)
 
-            // 5. status を success に更新
-            screenshot.status = .success
-            screenshot.errorMessage = nil
-            screenshot.updatedAt = Date()
-            try modelContext.save()
-
-        } catch {
-            // エラー時: status を failed に更新
-            screenshot.status = .failed
-            screenshot.errorMessage = error.localizedDescription
-            screenshot.retryCount += 1
-            screenshot.updatedAt = Date()
-            try? modelContext.save()
-
-            print("[AnalysisRepository] 解析に失敗: \(error.localizedDescription)")
-        }
+        // 5. status を success に更新
+        screenshot.status = .success
+        screenshot.errorMessage = nil
+        screenshot.updatedAt = Date()
+        try modelContext.save()
     }
 
     // MARK: - Private Methods

--- a/src/Mnemo/Mnemo/Services/AnalysisQueue.swift
+++ b/src/Mnemo/Mnemo/Services/AnalysisQueue.swift
@@ -1,0 +1,269 @@
+import Foundation
+import SwiftData
+import Network
+
+/// 画像解析の自動キュー管理サービス
+///
+/// 責務:
+/// - 画像インポート後の自動解析キューイング
+/// - 指数バックオフによる自動リトライ（30秒 / 2分 / 5分、最大 3 回）
+/// - NWPathMonitor によるオフライン検知・復帰時自動再開
+/// - 手動リトライ（上限なし、10 秒クールダウン）
+/// - 削除済み Screenshot の解析結果破棄
+@MainActor
+@Observable
+final class AnalysisQueue {
+
+    // MARK: - UI 公開プロパティ
+
+    private(set) var isProcessing = false
+    private(set) var pendingCount = 0
+    private(set) var currentScreenshot: Screenshot?
+    private(set) var isOnline = true
+
+    // MARK: - Dependencies
+
+    private let modelContext: ModelContext
+    private let analysisRepository: AnalysisRepository
+
+    // MARK: - Network Monitor
+
+    private let pathMonitor: NWPathMonitor
+    private let monitorQueue = DispatchQueue(label: "com.mnemo.networkMonitor")
+
+    // MARK: - Internal State
+
+    private var processingTask: Task<Void, Never>?
+    private var isStarted = false
+
+    // MARK: - Constants
+
+    private static let maxAutoRetries = 3
+    private static let manualRetryCooldown: TimeInterval = 10
+
+    // MARK: - Init
+
+    init(modelContext: ModelContext, analysisRepository: AnalysisRepository) {
+        self.modelContext = modelContext
+        self.analysisRepository = analysisRepository
+        self.pathMonitor = NWPathMonitor()
+    }
+
+    // MARK: - Lifecycle
+
+    /// アプリ起動時に呼び出す。ネットワーク監視開始 + 中断した処理の回復
+    func start() {
+        guard !isStarted else { return }
+        isStarted = true
+
+        startMonitoring()
+        recoverStaleProcessing()
+        updatePendingCount()
+
+        if pendingCount > 0 {
+            triggerProcessing()
+        }
+    }
+
+    /// アプリ終了時のクリーンアップ
+    func stop() {
+        pathMonitor.cancel()
+        processingTask?.cancel()
+        processingTask = nil
+        isStarted = false
+    }
+
+    // MARK: - Public API
+
+    /// 新しい Screenshot を解析キューに追加する
+    ///
+    /// Screenshot はすでに status: .pending で作成されている前提。
+    /// キューへの追加 = 処理ループの起動トリガー。
+    func enqueue(_ screenshots: [Screenshot]) {
+        updatePendingCount()
+        triggerProcessing()
+    }
+
+    /// 手動リトライ（DetailView から呼ばれる）
+    ///
+    /// 上限なし。ただし直近失敗から 10 秒のクールダウンを設ける。
+    func retryManually(_ screenshot: Screenshot) {
+        guard screenshot.status == .failed else { return }
+
+        screenshot.status = .pending
+        screenshot.updatedAt = Date()
+        try? modelContext.save()
+
+        updatePendingCount()
+        triggerProcessing()
+    }
+
+    /// 手動リトライが可能かどうか（10 秒クールダウン）
+    func canRetry(_ screenshot: Screenshot) -> Bool {
+        guard screenshot.status == .failed else { return false }
+        let elapsed = Date().timeIntervalSince(screenshot.updatedAt)
+        return elapsed >= Self.manualRetryCooldown
+    }
+
+    // MARK: - Network Monitoring
+
+    private func startMonitoring() {
+        pathMonitor.pathUpdateHandler = { [weak self] path in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                let wasOffline = !self.isOnline
+                self.isOnline = (path.status == .satisfied)
+
+                // オフライン → オンライン復帰時に処理再開
+                if wasOffline && self.isOnline {
+                    self.triggerProcessing()
+                }
+            }
+        }
+        pathMonitor.start(queue: monitorQueue)
+    }
+
+    // MARK: - Recovery
+
+    /// 前回 .processing のまま終了した Screenshot を .pending に戻す
+    private func recoverStaleProcessing() {
+        let allScreenshots = fetchAllScreenshots()
+        let stale = allScreenshots.filter { $0.status == .processing }
+
+        for screenshot in stale {
+            screenshot.status = .pending
+            screenshot.updatedAt = Date()
+        }
+
+        if !stale.isEmpty {
+            try? modelContext.save()
+            print("[AnalysisQueue] \(stale.count) 件の中断された処理を回復しました")
+        }
+    }
+
+    // MARK: - Processing
+
+    /// 処理ループを起動する（既に実行中なら何もしない）
+    private func triggerProcessing() {
+        guard processingTask == nil else { return }
+
+        processingTask = Task {
+            await processQueue()
+            processingTask = nil
+        }
+    }
+
+    /// 逐次処理ループ（コアロジック）
+    ///
+    /// pending な Screenshot を一つずつ取得し、AnalysisRepository で解析する。
+    /// 一時的エラーの場合はバックオフ後に再試行、永続的エラーの場合は .failed のまま。
+    private func processQueue() async {
+        isProcessing = true
+        defer {
+            isProcessing = false
+            currentScreenshot = nil
+            updatePendingCount()
+        }
+
+        while !Task.isCancelled {
+            // オフラインなら一時停止
+            guard isOnline else { break }
+
+            // 次の pending を取得
+            let pending = fetchPendingScreenshots()
+            guard let screenshot = pending.first else { break }
+
+            // 削除済みチェック
+            guard screenshotStillExists(screenshot.id) else { continue }
+
+            currentScreenshot = screenshot
+            updatePendingCount()
+
+            // 解析実行
+            do {
+                try await analysisRepository.analyzeScreenshot(screenshot)
+                // 成功 → 次の pending へ
+            } catch {
+                // 解析後に削除済みチェック
+                guard screenshotStillExists(screenshot.id) else { continue }
+
+                // エラー記録
+                screenshot.status = .failed
+                screenshot.errorMessage = error.localizedDescription
+                screenshot.retryCount += 1
+                screenshot.updatedAt = Date()
+                try? modelContext.save()
+
+                print("[AnalysisQueue] 解析失敗 (\(screenshot.retryCount)回目): \(error.localizedDescription)")
+
+                // 一時的エラーかつリトライ上限以内なら再キュー + バックオフ
+                if isTransientError(error) && screenshot.retryCount < Self.maxAutoRetries {
+                    screenshot.status = .pending
+                    try? modelContext.save()
+
+                    let delay = backoffInterval(for: screenshot.retryCount)
+                    print("[AnalysisQueue] \(delay)秒後にリトライします")
+                    try? await Task.sleep(for: .seconds(delay))
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// 全 Screenshot を取得する
+    private func fetchAllScreenshots() -> [Screenshot] {
+        let descriptor = FetchDescriptor<Screenshot>(
+            sortBy: [SortDescriptor(\.createdAt, order: .forward)]
+        )
+        return (try? modelContext.fetch(descriptor)) ?? []
+    }
+
+    /// pending な Screenshot を取得する（作成日順）
+    private func fetchPendingScreenshots() -> [Screenshot] {
+        let descriptor = FetchDescriptor<Screenshot>(
+            sortBy: [SortDescriptor(\.createdAt, order: .forward)]
+        )
+        guard let all = try? modelContext.fetch(descriptor) else { return [] }
+        return all.filter { $0.status == .pending }
+    }
+
+    /// pendingCount を更新する
+    private func updatePendingCount() {
+        pendingCount = fetchPendingScreenshots().count
+    }
+
+    /// Screenshot がまだ存在するか確認する（削除済み検出）
+    private func screenshotStillExists(_ id: UUID) -> Bool {
+        let all = fetchAllScreenshots()
+        return all.contains { $0.id == id }
+    }
+
+    /// エラーが一時的かどうかを判定する
+    ///
+    /// 一時的エラー → 自動リトライ対象
+    /// 永続的エラー → .failed のまま（手動リトライのみ）
+    private func isTransientError(_ error: Error) -> Bool {
+        if let apiError = error as? APIClientError {
+            switch apiError {
+            case .networkError, .rateLimited, .serverUnavailable:
+                return true
+            case .invalidURL, .decodingError, .httpError:
+                return false
+            }
+        }
+        // ImageStorage のエラー等はリトライしても無駄
+        return false
+    }
+
+    /// 指数バックオフの待機時間（秒）
+    ///
+    /// retryCount 1 → 30秒, 2 → 2分, 3 → 5分
+    private func backoffInterval(for retryCount: Int) -> TimeInterval {
+        switch retryCount {
+        case 1: return 30
+        case 2: return 120
+        default: return 300
+        }
+    }
+}

--- a/src/Mnemo/Mnemo/ViewModels/DetailViewModel.swift
+++ b/src/Mnemo/Mnemo/ViewModels/DetailViewModel.swift
@@ -27,8 +27,10 @@ final class DetailViewModel {
         self.cachedImage = Self.loadImage(from: screenshot.localPath)
     }
 
-    /// @Environment からの遅延注入用
+    /// @Environment からの遅延注入用（一度だけ設定される）
     func setAnalysisQueue(_ queue: AnalysisQueue) {
+        // Ensure the analysisQueue is only initialized once, even if called multiple times
+        guard analysisQueue == nil else { return }
         self.analysisQueue = queue
     }
     
@@ -143,11 +145,19 @@ final class DetailViewModel {
 
     /// 手動リトライが可能か
     var canRetry: Bool {
-        analysisQueue?.canRetry(screenshot) ?? false
+        guard let analysisQueue else {
+            assertionFailure("DetailViewModel.analysisQueue is nil; retry availability cannot be determined. Verify dependency injection.")
+            return false
+        }
+        return analysisQueue.canRetry(screenshot)
     }
 
     /// 手動リトライ実行
     func retry() {
-        analysisQueue?.retryManually(screenshot)
+        guard let analysisQueue else {
+            assertionFailure("DetailViewModel.analysisQueue is nil; cannot perform manual retry. Verify dependency injection.")
+            return
+        }
+        analysisQueue.retryManually(screenshot)
     }
 }

--- a/src/Mnemo/Mnemo/ViewModels/DetailViewModel.swift
+++ b/src/Mnemo/Mnemo/ViewModels/DetailViewModel.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@MainActor
 @Observable
 final class DetailViewModel {
 
@@ -15,6 +16,7 @@ final class DetailViewModel {
 
     let screenshot: Screenshot
     private let repository: ScreenshotRepository
+    private var analysisQueue: AnalysisQueue?
 
     // MARK: - Init
 
@@ -23,6 +25,11 @@ final class DetailViewModel {
         self.repository = repository
         // 初期化時に画像を読み込んでキャッシュする
         self.cachedImage = Self.loadImage(from: screenshot.localPath)
+    }
+
+    /// @Environment からの遅延注入用
+    func setAnalysisQueue(_ queue: AnalysisQueue) {
+        self.analysisQueue = queue
     }
     
     /// 画像をディスクから読み込む（プライベートヘルパー）
@@ -130,5 +137,17 @@ final class DetailViewModel {
     /// OCR テキストが存在するか
     var hasOCRText: Bool {
         screenshot.ocrText != nil
+    }
+
+    // MARK: - Retry
+
+    /// 手動リトライが可能か
+    var canRetry: Bool {
+        analysisQueue?.canRetry(screenshot) ?? false
+    }
+
+    /// 手動リトライ実行
+    func retry() {
+        analysisQueue?.retryManually(screenshot)
     }
 }

--- a/src/Mnemo/Mnemo/ViewModels/LibraryViewModel.swift
+++ b/src/Mnemo/Mnemo/ViewModels/LibraryViewModel.swift
@@ -14,11 +14,11 @@ final class LibraryViewModel {
     // MARK: - Dependencies
 
     private(set) var repository: ScreenshotRepository
-    private let analysisQueue: AnalysisQueue?
+    private let analysisQueue: AnalysisQueue
 
     // MARK: - Init
 
-    init(repository: ScreenshotRepository, analysisQueue: AnalysisQueue? = nil) {
+    init(repository: ScreenshotRepository, analysisQueue: AnalysisQueue) {
         self.repository = repository
         self.analysisQueue = analysisQueue
     }
@@ -68,7 +68,7 @@ final class LibraryViewModel {
         }
 
         // 解析キューに追加
-        analysisQueue?.enqueue(result.screenshots)
+        analysisQueue.enqueue(result.screenshots)
 
         // 一覧を更新
         loadScreenshots()

--- a/src/Mnemo/Mnemo/ViewModels/LibraryViewModel.swift
+++ b/src/Mnemo/Mnemo/ViewModels/LibraryViewModel.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import PhotosUI
 
+@MainActor
 @Observable
 final class LibraryViewModel {
 
@@ -13,11 +14,13 @@ final class LibraryViewModel {
     // MARK: - Dependencies
 
     private(set) var repository: ScreenshotRepository
+    private let analysisQueue: AnalysisQueue?
 
     // MARK: - Init
 
-    init(repository: ScreenshotRepository) {
+    init(repository: ScreenshotRepository, analysisQueue: AnalysisQueue? = nil) {
         self.repository = repository
+        self.analysisQueue = analysisQueue
     }
 
     // MARK: - Actions
@@ -63,6 +66,9 @@ final class LibraryViewModel {
         if totalFailed > 0 {
             errorMessage = "\(totalFailed)枚の画像が取り込めませんでした"
         }
+
+        // 解析キューに追加
+        analysisQueue?.enqueue(result.screenshots)
 
         // 一覧を更新
         loadScreenshots()

--- a/src/Mnemo/Mnemo/Views/Detail/DetailView.swift
+++ b/src/Mnemo/Mnemo/Views/Detail/DetailView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct DetailView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(AnalysisQueue.self) private var analysisQueue
     @State private var viewModel: DetailViewModel
     @State private var zoomScale: CGFloat = 1.0
     @State private var lastZoomScale: CGFloat = 1.0
@@ -56,6 +57,9 @@ struct DetailView: View {
                     Image(systemName: "trash")
                 }
             }
+        }
+        .task {
+            viewModel.setAnalysisQueue(analysisQueue)
         }
         .confirmationDialog(
             "この画像を削除しますか？",
@@ -199,6 +203,18 @@ struct DetailView: View {
                 Text(viewModel.statusText)
                     .font(.subheadline)
                     .foregroundStyle(viewModel.statusColor)
+
+                Spacer()
+
+                // 再試行ボタン
+                if viewModel.canRetry {
+                    Button {
+                        viewModel.retry()
+                    } label: {
+                        Label("再試行", systemImage: "arrow.clockwise")
+                            .font(.subheadline)
+                    }
+                }
             }
 
             Divider()

--- a/src/Mnemo/Mnemo/Views/Library/LibraryView.swift
+++ b/src/Mnemo/Mnemo/Views/Library/LibraryView.swift
@@ -3,6 +3,7 @@ import PhotosUI
 
 struct LibraryView: View {
     @Environment(\.modelContext) private var modelContext
+    @Environment(AnalysisQueue.self) private var analysisQueue
     @State private var viewModel: LibraryViewModel?
     @State private var selectedItems: [PhotosPickerItem] = []
 
@@ -43,7 +44,8 @@ struct LibraryView: View {
             .task {
                 if viewModel == nil {
                     let vm = LibraryViewModel(
-                        repository: ScreenshotRepository(modelContext: modelContext)
+                        repository: ScreenshotRepository(modelContext: modelContext),
+                        analysisQueue: analysisQueue
                     )
                     viewModel = vm
                 }


### PR DESCRIPTION
## Summary
- 画像インポート後に自動で AI 解析を開始する `AnalysisQueue` サービスを新規追加
- `NWPathMonitor` によるオフライン検知 → オンライン復帰時に自動再開
- 指数バックオフリトライ（30秒 / 2分 / 5分、最大3回）、一時的/永続的エラーの判別
- 詳細画面に「再試行」ボタンを追加（手動リトライ、10秒クールダウン）
- `MnemoApp` で `ModelContainer` / `APIClient` / `AnalysisQueue` の依存注入を設定
- `AnalysisRepository.analyzeScreenshot` を `throws` に変更し、ステータス管理を `AnalysisQueue` に委譲

## Test plan
- [x] `xcodebuild` でビルドが通ること
- [ ] 画像インポート後に自動で解析キューが処理を開始すること
- [ ] 失敗時に指数バックオフで自動リトライされること（最大3回）
- [ ] 詳細画面で失敗時にリトライボタンが表示され、手動リトライできること
- [ ] 機内モード ON → キュー保持 → OFF で自動送信再開
- [ ] 解析中に画像を削除してもクラッシュしないこと

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)