### PR TITLE
feat: FastAPI API キー認証ミドルウェア

### DIFF
--- a/src/server/app/auth.py
+++ b/src/server/app/auth.py
@@ -1,0 +1,56 @@
+"""API キー認証の依存関数"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from fastapi import HTTPException, Security
+from fastapi.security import APIKeyHeader
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+_api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+_device_id_header = APIKeyHeader(name="X-Device-ID", auto_error=False)
+
+
+async def verify_api_key(
+    api_key: Optional[str] = Security(_api_key_header),
+    device_id: Optional[str] = Security(_device_id_header),
+) -> str:
+    """
+    X-API-Key ヘッダーを config の api_key と照合し、X-Device-ID の存在を確認する。
+
+    api_key が未設定（空文字）の場合は認証をスキップする（ローカル開発用）。
+    認証成功時は device_id を返す。
+    """
+    configured_key = settings.api_key
+
+    # API キーが未設定の場合は認証スキップ
+    if not configured_key:
+        return device_id or "unknown"
+
+    if not api_key:
+        logger.warning("Missing X-API-Key header")
+        raise HTTPException(
+            status_code=401,
+            detail="認証エラー: API キーが必要です。",
+        )
+
+    if api_key != configured_key:
+        logger.warning("Invalid API key attempt")
+        raise HTTPException(
+            status_code=401,
+            detail="認証エラー: API キーが無効です。",
+        )
+
+    if not device_id:
+        logger.warning("Missing X-Device-ID header (api_key valid)")
+        raise HTTPException(
+            status_code=401,
+            detail="認証エラー: デバイス ID が必要です。",
+        )
+
+    return device_id

--- a/src/server/app/routers/analyze.py
+++ b/src/server/app/routers/analyze.py
@@ -2,8 +2,9 @@
 
 import logging
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
+from app.auth import verify_api_key
 from app.schemas.analyze import AnalyzeRequest, AnalyzeResponse, TagItem
 from app.services.embedding import generate_embedding
 from app.services.vision import analyze_image
@@ -14,7 +15,9 @@ router = APIRouter()
 
 
 @router.post("/analyze", response_model=AnalyzeResponse)
-async def analyze(request: AnalyzeRequest) -> AnalyzeResponse:
+async def analyze(
+    request: AnalyzeRequest, device_id: str = Depends(verify_api_key)
+) -> AnalyzeResponse:
     """
     画像を AI で解析し、OCR テキスト・タグ・説明文・埋め込みベクトルを返す。
 

--- a/src/server/app/routers/embed.py
+++ b/src/server/app/routers/embed.py
@@ -2,8 +2,9 @@
 
 import logging
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
+from app.auth import verify_api_key
 from app.schemas.embed import (
     EmbedRequest,
     EmbedResponse,
@@ -18,7 +19,9 @@ router = APIRouter()
 
 
 @router.post("/embed", response_model=EmbedResponse)
-async def embed(request: EmbedRequest) -> EmbedResponse:
+async def embed(
+    request: EmbedRequest, device_id: str = Depends(verify_api_key)
+) -> EmbedResponse:
     """テキストから埋め込みベクトルを生成する。"""
     try:
         logger.info("Generating embedding for text (%d chars)", len(request.text))
@@ -53,7 +56,9 @@ async def embed(request: EmbedRequest) -> EmbedResponse:
 
 
 @router.post("/search/embed", response_model=SearchEmbedResponse)
-async def search_embed(request: SearchEmbedRequest) -> SearchEmbedResponse:
+async def search_embed(
+    request: SearchEmbedRequest, device_id: str = Depends(verify_api_key)
+) -> SearchEmbedResponse:
     """検索クエリから埋め込みベクトルを生成する。"""
     try:
         logger.info("Generating search embedding for query (%d chars)", len(request.query))

--- a/src/server/local.settings.json.example
+++ b/src/server/local.settings.json.example
@@ -7,7 +7,7 @@
     "AZURE_AI_PROJECT_CONNECTION_STRING": "",
     "AZURE_OPENAI_DEPLOYMENT_VISION": "gpt-5-mini",
     "AZURE_OPENAI_DEPLOYMENT_EMBEDDING": "text-embedding-3-small",
-    "API_KEY": "",
+    "API_KEY": "__SET_YOUR_API_KEY_HERE__",
     "EMBEDDING_DIMENSIONS": "512"
   }
 }

--- a/src/server/tests/test_auth.py
+++ b/src/server/tests/test_auth.py
@@ -1,0 +1,132 @@
+"""API キー認証のテスト"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.auth import verify_api_key
+from app.routers import health
+
+
+def _create_app() -> FastAPI:
+    """認証付きテスト用 FastAPI アプリを作成する。"""
+    from fastapi import Depends
+
+    app = FastAPI()
+
+    # /health — 認証なし
+    app.include_router(health.router)
+
+    # /protected — 認証あり（テスト用ダミー）
+    @app.post("/protected")
+    async def protected_endpoint(device_id: str = Depends(verify_api_key)):
+        return {"device_id": device_id}
+
+    return app
+
+
+# --- API キーが設定されている場合 ---
+
+
+class TestAuthWithApiKey:
+    """API_KEY が設定されている場合のテスト。"""
+
+    @pytest.fixture()
+    def client(self):
+        with patch("app.auth.settings") as mock_settings:
+            mock_settings.api_key = "test-secret-key"
+            app = _create_app()
+            yield TestClient(app)
+
+    def test_valid_api_key_and_device_id(self, client):
+        """正しい API キーとデバイス ID で 200 が返る。"""
+        response = client.post(
+            "/protected",
+            headers={
+                "X-API-Key": "test-secret-key",
+                "X-Device-ID": "device-123",
+            },
+        )
+        assert response.status_code == 200
+        assert response.json() == {"device_id": "device-123"}
+
+    def test_missing_api_key(self, client):
+        """API キーヘッダーがない場合は 401 が返る。"""
+        response = client.post(
+            "/protected",
+            headers={"X-Device-ID": "device-123"},
+        )
+        assert response.status_code == 401
+        assert "API キー" in response.json()["detail"]
+
+    def test_invalid_api_key(self, client):
+        """不正な API キーの場合は 401 が返る。"""
+        response = client.post(
+            "/protected",
+            headers={
+                "X-API-Key": "wrong-key",
+                "X-Device-ID": "device-123",
+            },
+        )
+        assert response.status_code == 401
+        assert "無効" in response.json()["detail"]
+
+    def test_missing_device_id(self, client):
+        """デバイス ID ヘッダーがない場合は 401 が返る。"""
+        response = client.post(
+            "/protected",
+            headers={"X-API-Key": "test-secret-key"},
+        )
+        assert response.status_code == 401
+        assert "デバイス ID" in response.json()["detail"]
+
+
+# --- API キーが未設定の場合（ローカル開発用） ---
+
+
+class TestAuthWithoutApiKey:
+    """API_KEY が空文字の場合のテスト（認証スキップ）。"""
+
+    @pytest.fixture()
+    def client(self):
+        with patch("app.auth.settings") as mock_settings:
+            mock_settings.api_key = ""
+            app = _create_app()
+            yield TestClient(app)
+
+    def test_no_auth_required(self, client):
+        """API キー未設定時はヘッダーなしでもアクセスできる。"""
+        response = client.post("/protected")
+        assert response.status_code == 200
+        assert response.json() == {"device_id": "unknown"}
+
+    def test_device_id_passthrough(self, client):
+        """API キー未設定時でもデバイス ID は渡される。"""
+        response = client.post(
+            "/protected",
+            headers={"X-Device-ID": "device-456"},
+        )
+        assert response.status_code == 200
+        assert response.json() == {"device_id": "device-456"}
+
+
+# --- /health は認証不要 ---
+
+
+class TestHealthNoAuth:
+    """/health エンドポイントは認証なしでアクセスできる。"""
+
+    @pytest.fixture()
+    def client(self):
+        with patch("app.auth.settings") as mock_settings:
+            mock_settings.api_key = "test-secret-key"
+            app = _create_app()
+            yield TestClient(app)
+
+    def test_health_without_auth(self, client):
+        """/health は API キーなしでも 200 が返る。"""
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary

- FastAPI の `Depends()` を使った API キー認証依存関数 (`app/auth.py`) を新規作成
- `/analyze`, `/embed`, `/search/embed` に認証を適用（`X-API-Key` + `X-Device-ID` 検証）
- `/health` は認証不要のまま維持
- `API_KEY` が空文字の場合は認証スキップ（ローカル開発用）
- pytest テスト 7 件追加（認証成功・失敗・スキップ・/health）

## Test plan

- [x] `pytest tests/test_auth.py` — 7 テスト全パス
- [ ] ローカルサーバーで API キー設定時に認証が動作することを確認
- [ ] API キーなしで `/analyze` が 401 を返すことを確認
- [ ] `/health` が API キーなしでも 200 を返すことを確認

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)